### PR TITLE
uacpi: add missing internal/stdlib.h includes

### DIFF
--- a/source/event.c
+++ b/source/event.c
@@ -8,6 +8,7 @@
 #include <uacpi/internal/notify.h>
 #include <uacpi/internal/utilities.h>
 #include <uacpi/internal/mutex.h>
+#include <uacpi/internal/stdlib.h>
 #include <uacpi/acpi.h>
 
 #define UACPI_EVENT_DISABLED 0

--- a/source/notify.c
+++ b/source/notify.c
@@ -4,6 +4,7 @@
 #include <uacpi/internal/log.h>
 #include <uacpi/internal/mutex.h>
 #include <uacpi/internal/utilities.h>
+#include <uacpi/internal/stdlib.h>
 #include <uacpi/kernel_api.h>
 
 static uacpi_handle notify_mutex;


### PR DESCRIPTION
A few implicit declarations are caused when compiling with ``UACPI_NATIVE_ALLOC_ZEROED`` because of these includes missing.