### PR TITLE
acpi.h: Add WAET table, add signature macros for SPCR and DBG2 tables, and comment about revisions 3, 4

### DIFF
--- a/include/uacpi/acpi.h
+++ b/include/uacpi/acpi.h
@@ -24,6 +24,8 @@
 #define ACPI_SSDT_SIGNATURE "SSDT"
 #define ACPI_PSDT_SIGNATURE "PSDT"
 #define ACPI_ECDT_SIGNATURE "ECDT"
+#define ACPI_DBG2_SIGNATURE "DBG2"
+#define ACPI_SPCR_SIGNATURE "SPCR"
 #define ACPI_RHCT_SIGNATURE "RHCT"
 #define ACPI_DMAR_SIGNATURE "DMAR"
 #define ACPI_WAET_SIGNATURE "WAET"
@@ -1138,7 +1140,11 @@ UACPI_PACKED(struct acpi_spcr {
     uacpi_u8 pci_function_number;
     uacpi_u32 pci_flags;
     uacpi_u8 pci_segment;
+
+    // revision >= 3
     uacpi_u32 uart_clock_frequency;
+
+    // revision >= 4
     uacpi_u32 precise_baud_rate;
     uacpi_u16 namespace_string_length;
     uacpi_u16 namespace_string_offset;

--- a/include/uacpi/acpi.h
+++ b/include/uacpi/acpi.h
@@ -26,6 +26,7 @@
 #define ACPI_ECDT_SIGNATURE "ECDT"
 #define ACPI_RHCT_SIGNATURE "RHCT"
 #define ACPI_DMAR_SIGNATURE "DMAR"
+#define ACPI_WAET_SIGNATURE "WAET"
 
 #define ACPI_AS_ID_SYS_MEM       0x00
 #define ACPI_AS_ID_SYS_IO        0x01
@@ -1702,3 +1703,13 @@ UACPI_PACKED(struct acpi_dmar_sidp {
     struct acpi_dmar_dss entries[];
 })
 UACPI_EXPECT_SIZEOF(struct acpi_dmar_sidp, 8);
+
+// acpi_waet->flags
+#define ACPI_WAET_RTC_GOOD (1 << 0)
+#define ACPI_WAET_ACPI_PM_TIMER_GOOD (1 << 1)
+
+UACPI_PACKED(struct acpi_waet {
+    struct acpi_sdt_hdr hdr;
+    uacpi_u32 flags;
+})
+UACPI_EXPECT_SIZEOF(struct acpi_waet, 40);


### PR DESCRIPTION
Add the WAET table (which gets passed by QEMU), and macros for SPCR and DBG2 tables about fields only available in revision 3 and 4

The WAET version 1.0 spec can be found here http://download.microsoft.com/download/7/E/7/7E7662CF-CBEA-470B-A97E-CE7CE0D98DC2/WAET.docx
(also, qemu source is in hw/i386/acpi-build.c:1634)